### PR TITLE
Expose publisher as a middleware attribute

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,9 +5,14 @@ module.exports = function (options) {
   options = options || {};
   var publisher = new Publisher(options.port, options.host, options.scope);
 
-  return function publish(name, value) {
+  function publish(name, value) {
     publisher.publish(name, value);
   };
+
+  // Attach publisher to middleware so 'warn' event can be listened on.
+  publish.publisher = publisher;
+
+  return publish;
 };
 
 function Publisher(port, host, scope) {

--- a/test.js
+++ b/test.js
@@ -32,6 +32,8 @@ function listening(er) {
 function test() {
   var publish = statsd({port: port});
 
+  assert.equal(publish.publisher.port, port);
+
   function write(name, value, type) {
     expected.push(util.format('%s:%d|%s', name, value, type));
     publish(name, value);


### PR DESCRIPTION
Publisher is useful for unit-testing, and also to allow the 'warn' event
to be listened on, for debugging.
