### PR TITLE
Work-around node cluster bugs with dgram.send()

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ function Publisher(port, host, scope) {
   this.stats = new Lynx(this.host, this.port, {
     scope: this.scope,
     on_error: this.onError.bind(this),
+    socket: this.socket,
   });
 }
 


### PR DESCRIPTION
See joyent/node#8027, work-around is to create a single dgram socket,
and to pass it to Lynx.
